### PR TITLE
Include libtool-bin in dependencies.

### DIFF
--- a/_pages/docs/C_Setup_OS.md
+++ b/_pages/docs/C_Setup_OS.md
@@ -64,7 +64,7 @@ The following packages need to be installed on Ubuntu 16.04.2 (server):
 
 ````
 apt-get install gcc gperf bison flex texinfo help2man make libncurses5-dev \
-	python-dev
+	python-dev libtool-bin
 ````
 
 macOS (a.k.a Mac OS X, OS X)


### PR DESCRIPTION
From Ubuntu 16.04 and Debian Jessie,
libtool-bin package is needed for /usr/bin/libtool.

As stated on https://crosstool-ng.github.io/docs/os-setup/

> If on the other hand you encounter a dependency not listed here, please let us know over the mailing list or via a pull request!

Here you are.
