### PR TITLE
Update typo in variable

### DIFF
--- a/_pages/docs/3_Configuration.md
+++ b/_pages/docs/3_Configuration.md
@@ -71,7 +71,7 @@ Interesting config options
     directory, enter it here. That will speed up the retrieving phase,
     where crosstool-NG would otherwise download those tarballs.
 
--   `CT_PREFIX_DIR`: This is where the toolchain will be installed in
+-   `CT_PREFIX`: This is where the toolchain will be installed in
     (and for now, where it will run from). Common use is to add the
     target tuple in the directory path, such as (see above):
     `/opt/x-tools/${CT_TARGET}`.


### PR DESCRIPTION
as I noticed - in crosstool-ng menuconfig using env. variable `${CT_PREFIX}` instead of `${CT_PREFIX_DIR}`