### PR TITLE
FIx macOS instructions formatting and dependency

### DIFF
--- a/_pages/docs/C_Setup_OS.md
+++ b/_pages/docs/C_Setup_OS.md
@@ -173,57 +173,67 @@ Run `brew doctor` to make sure everything is setup properly. If you have any
 problems, please refer to the [homebrew](brew.sh) website.
 
 1. Install the following packages:
-```
-autoconf automake bash binutils bison gawk git gnu-sed gnu-tar gettext help2man make ncurses readline wget xz zstd
-```
+
+   ```
+   autoconf automake bash binutils bison gawk git gnu-sed gnu-tar gettext help2man make ncurses readline wget xz zstd
+   ```
+   
    Then append the following to your shell's profile script (`~/.profile` or
    `~/.zprofile`):
-```
-BREW_PREFIX="$(brew --prefix)"
-
-PATH=${PATH}:${BREW_PREFIX}/opt/binutils/bin"
-PATH=${BREW_PREFIX}/opt/bison/bin:${PATH}"
-PATH=/Volumes/crosstool-ng/bin:${PATH}"
-export PATH
-
-LDFLAGS="-L${BREW_PREFIX}/opt/binutils/lib"
-LDFLAGS+=" -L${BREW_PREFIX}/opt/bison/lib"
-LDFLAGS+=" -L${BREW_PREFIX}/opt/ncurses/lib"
-export LDFLAGS
-
-CPPFLAGS="-I${BREW_PREFIX}/opt/binutils/include"
-CPPFLAGS+=" -I${BREW_PREFIX}/opt/ncurses/include"
-export CPPFLAGS
-
-export PKG_CONFIG_PATH="${BREW_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
-```
+   
+   ```
+   BREW_PREFIX="$(brew --prefix)"
+   
+   PATH=${PATH}:${BREW_PREFIX}/opt/binutils/bin"
+   PATH=${BREW_PREFIX}/opt/bison/bin:${PATH}"
+   PATH=/Volumes/crosstool-ng/bin:${PATH}"
+   export PATH
+   
+   LDFLAGS="-L${BREW_PREFIX}/opt/binutils/lib"
+   LDFLAGS+=" -L${BREW_PREFIX}/opt/bison/lib"
+   LDFLAGS+=" -L${BREW_PREFIX}/opt/ncurses/lib"
+   export LDFLAGS
+   
+   CPPFLAGS="-I${BREW_PREFIX}/opt/binutils/include"
+   CPPFLAGS+=" -I${BREW_PREFIX}/opt/ncurses/include"
+   export CPPFLAGS
+   
+   export PKG_CONFIG_PATH="${BREW_PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH}"
+   ```
 
 2. You have to use a case sensitive file system for crosstool-NG's build and target
    directories. Use a disk or disk image with a case sensitive FS that you
    mount somewhere.
-```
-cd $HOME
-hdiutil create -size 40g -fs "Case-sensitive APFS" -type SPARSE -volname crosstool-ng crosstool-ng
-```
+
+   ```
+   cd $HOME
+   hdiutil create -size 40g -fs "Case-sensitive APFS" -type SPARSE -volname crosstool-ng crosstool-ng
+   ```
+
    This will create `crosstool-ng.sparseimage`. You can mount it by typing:
-```
-cd $HOME
-hdiutil mount crosstool-ng.sparseimage
-```
+
+   ```
+   cd $HOME
+   hdiutil mount crosstool-ng.sparseimage
+   ```
+
    And unmount it by typing:
-```
-hdiutil unmount /Volumes/crosstool-ng
-```
+
+   ```
+   hdiutil unmount /Volumes/crosstool-ng
+   ```
 
 3. You can now build crosstool-ng on that volume by cloning the git repo or
    untaring a release in `/Volumes/crosstool-ng` and bootstrapping (only if from
    git) and configuring and building crosstool-ng.
-```
-./bootstrap # again, only needed if you got the source from git
-./configure --prefix=/Volumes/crosstool-ng
-make
-make install
-```
+
+   ```
+   ./bootstrap # again, only needed if you got the source from git
+   ./configure --prefix=/Volumes/crosstool-ng
+   make
+   make install
+   ```
+
    Close your terminal app and open it again to get a new shell and verify your
    enviornment variables are set with `env`.
 

--- a/_pages/docs/C_Setup_OS.md
+++ b/_pages/docs/C_Setup_OS.md
@@ -160,7 +160,7 @@ macOS (a.k.a Mac OS X, OS X)
 ----------------------------
 
 *Originally contributed by: Titus von Boxberg*
-*Updates by: Bryan Hundven*
+*Updates by: Bryan Hundven, RigoLigo*
 
 These instructions have been tested on macOS Sonoma (14.3.1). I have not tested
 on any other version with the following commands. *YMMV*
@@ -175,7 +175,7 @@ problems, please refer to the [homebrew](brew.sh) website.
 1. Install the following packages:
 
    ```
-   autoconf automake bash binutils bison gawk git gnu-sed gnu-tar gettext help2man make ncurses readline wget xz zstd
+   autoconf automake bash binutils bison gawk git gnu-sed gnu-tar gettext help2man libtool make ncurses readline texinfo wget xz zstd
    ```
    
    Then append the following to your shell's profile script (`~/.profile` or
@@ -184,9 +184,10 @@ problems, please refer to the [homebrew](brew.sh) website.
    ```
    BREW_PREFIX="$(brew --prefix)"
    
-   PATH=${PATH}:${BREW_PREFIX}/opt/binutils/bin"
-   PATH=${BREW_PREFIX}/opt/bison/bin:${PATH}"
-   PATH=/Volumes/crosstool-ng/bin:${PATH}"
+   PATH="${PATH}:${BREW_PREFIX}/opt/binutils/bin"
+   PATH="${BREW_PREFIX}/opt/bison/bin:${PATH}"
+   PATH="${BREW_PREFIX}/opt/libtool/libexec/gnubin:${PATH}"
+   PATH="/Volumes/crosstool-ng/bin:${PATH}"
    export PATH
    
    LDFLAGS="-L${BREW_PREFIX}/opt/binutils/lib"


### PR DESCRIPTION
<img width="918" alt="图片" src="https://github.com/user-attachments/assets/af2f186d-a8c5-4bba-a348-86f14f29d67a" />


Jekyll has a more strict policy on using indentation and new lines. This file was fixed once before and it's still not looking right on Jekyll site; hopefully this time it fixes this documentation once and for all.

Reference: my own blog that has correct formatting, which was written like how I changed this document [source](https://raw.githubusercontent.com/RigoLigoRLC/rigoligorlc.github.io/refs/heads/master/blog/reverse-engineering/loongson-ejtag/03-official-probe.md) [deployment](https://pages.rigoligo.cc/blog/reverse-engineering/loongson-ejtag/03-official-probe.html)

EDIT: `texinfo` and `libtool` dependency was added when I found that these are required but not present in the documentation.