### PR TITLE
Simplify configuration extraction instructions

### DIFF
--- a/_pages/docs/3_Configuration.md
+++ b/_pages/docs/3_Configuration.md
@@ -126,13 +126,6 @@ Or, if your `build.log` file is compressed (most probably!):
 
     bzcat build.log.bz2 | ct-ng extractconfig >.config
 
-The above commands will dump the configuration to `stdout`, so to rebuild a
-toolchain with this configuration, just redirect the output to the `.config`
-file:
-
-    ${CT_TARGET}-ct-ng.config >.config
-    ct-ng oldconfig
-
 Then, you can review and change the configuration by running:
 
     ct-ng menuconfig


### PR DESCRIPTION
Removed instructions for redirecting output to .config file because it was already redirected into the file in the first 2 examples.